### PR TITLE
Closes coleam00/mcp-crawl4ai-rag#35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN uv pip install --system -e . && \
 EXPOSE ${PORT}
 
 # Command to run the MCP server
-CMD ["uv", "run", "src/crawl4ai_mcp.py"]
+CMD ["python", "src/crawl4ai_mcp.py"]


### PR DESCRIPTION
The command when running the Docker image has been changed from

The command `uv run src/crawl4ai_mcp.py` creates a virtual environment and redownloads the Python packages before running the program.

The new command `python src/crawl4ai_mcp.py` runs using the system-wide installed packages which was previously downloaded in `uv pip install --system -e .`

Using `docker ps -s`, we see this reduces the running container's size to `71.8MB` from the initial `6.01GB` (which contains mainly duplicate packages from the `7.37GB` image).
