### PR TITLE
fix(mcp): restore .env.example for onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,59 +1,37 @@
-# The transport for the MCP server - either 'sse' or 'stdio' (defaults to sse if left empty)
-TRANSPORT=
+#############################################
+# Crawl4AI RAG MCP — Environment Template
+#############################################
+# Copy this file to .env and fill values.
+# Do NOT commit real secrets.
 
-# Host to bind to if using sse as the transport (leave empty if using stdio)
-# Set this to 0.0.0.0 if using Docker, otherwise set to localhost (if using uv)
-HOST=
+# MCP server
+HOST=0.0.0.0
+PORT=8051
+TRANSPORT=sse  # sse | stdio
 
-# Port to listen on if using sse as the transport (leave empty if using stdio)
-PORT=
+# OpenAI (embeddings and summaries)
+OPENAI_API_KEY=your_openai_api_key
+# Model used for contextual operations (see README)
+MODEL_CHOICE=gpt-4.1-nano
 
-# Get your Open AI API Key by following these instructions -
-# https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key
-# This is for the embedding model - text-embed-small-3 will be used
-OPENAI_API_KEY=
-
-# The LLM you want to use for summaries and contextual embeddings
-# Generally this is a very cheap and fast LLM like gpt-4.1-nano
-MODEL_CHOICE=
-
-# RAG strategies - set these to "true" or "false" (default to "false")
-# USE_CONTEXTUAL_EMBEDDINGS: Enhances embeddings with contextual information for better retrieval
+# Optional RAG strategies ("true" | "false")
 USE_CONTEXTUAL_EMBEDDINGS=false
-
-# USE_HYBRID_SEARCH: Combines vector similarity search with keyword search for better results
 USE_HYBRID_SEARCH=false
-
-# USE_AGENTIC_RAG: Enables code example extraction, storage, and specialized code search functionality
 USE_AGENTIC_RAG=false
-
-# USE_RERANKING: Applies cross-encoder reranking to improve search result relevance
 USE_RERANKING=false
-
-# USE_KNOWLEDGE_GRAPH: Enables AI hallucination detection and repository parsing tools using Neo4j
-# If you set this to true, you must also set the Neo4j environment variables below.
 USE_KNOWLEDGE_GRAPH=false
 
-# For the Supabase version (sample_supabase_agent.py), set your Supabase URL and Service Key.
-# Get your SUPABASE_URL from the API section of your Supabase project settings -
-# https://supabase.com/dashboard/project/<your project ID>/settings/api
-SUPABASE_URL=
+# Supabase (vector store)
+SUPABASE_URL=your_supabase_project_url
+SUPABASE_SERVICE_KEY=your_supabase_service_key
 
-# Get your SUPABASE_SERVICE_KEY from the API section of your Supabase project settings -
-# https://supabase.com/dashboard/project/<your project ID>/settings/api
-# On this page it is called the service_role secret.
-SUPABASE_SERVICE_KEY=
-
-# Neo4j Configuration for Knowledge Graph Tools
-# These are required for the AI hallucination detection and repository parsing tools
-# Leave empty to disable knowledge graph functionality
-
-# Neo4j connection URI - use bolt://localhost:7687 for local, neo4j:// for cloud instances
-# IMPORTANT: If running the MCP server through Docker, change localhost to host.docker.internal
+# Neo4j (required if USE_KNOWLEDGE_GRAPH=true)
 NEO4J_URI=bolt://localhost:7687
-
-# Neo4j username (usually 'neo4j' for default installations)
 NEO4J_USER=neo4j
+NEO4J_PASSWORD=your_neo4j_password
 
-# Neo4j password for your database instance
-NEO4J_PASSWORD=
+# Notes
+# - This template mirrors variables used by src/utils.py and documented in README.md
+# - If running via Docker, you can pass these with -e or a --env-file
+# - If using stdio transport with some MCP clients, set TRANSPORT=stdio
+

--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ Alternatively, install Neo4j directly:
 
 ## Configuration
 
+Quick setup:
+
+```bash
+cp .env.example .env
+# then open .env and fill the values
+```
+
+Alternatively, create a `.env` from scratch using the variables below.
+
 Create a `.env` file in the project root with the following variables:
 
 ```


### PR DESCRIPTION
fix(mcp): restore .env.example template for Crawl4AI RAG MCP

Problem
- `.env.example` was removed, breaking the documented setup flow (`cp .env.example .env`) and causing runtime failures when `SUPABASE_URL` / `SUPABASE_SERVICE_KEY` / `NEO4J_*` aren’t set.

Solution
- Re-add a minimal `.env.example` that mirrors variables referenced by the code and README:
  - `HOST`, `PORT`, `TRANSPORT`
  - `OPENAI_API_KEY`, `MODEL_CHOICE`
  - `USE_CONTEXTUAL_EMBEDDINGS`, `USE_HYBRID_SEARCH`, `USE_AGENTIC_RAG`, `USE_RERANKING`, `USE_KNOWLEDGE_GRAPH`
  - `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`
  - `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`

Why safe
- No runtime code changes; only restores developer onboarding ergonomics.
- Matches imports in `src/utils.py` and `src/crawl4ai_mcp.py`.

Notes
- Optionally add a one-liner in README to run `cp .env.example .env`.
